### PR TITLE
Remove pawn sex-change thoughts on Pawn Generation

### DIFF
--- a/Source/Genes/Gender/GenderUtility.cs
+++ b/Source/Genes/Gender/GenderUtility.cs
@@ -1,9 +1,10 @@
 ﻿using Verse;
 using rjw;
 using RimWorld;
-using System.Collections;
 using System.Linq;
 using System;
+using System.Collections.Generic;
+using HarmonyLib;
 
 namespace RJW_Genes
 {
@@ -68,6 +69,30 @@ namespace RJW_Genes
 
             // Force Redraw at the spot
             pawn.Drawer.renderer.graphics.SetAllGraphicsDirty();
+        }
+
+        // Fetch these once at load time because they don't change inside RJW
+        private static readonly List<HediffDef> wasSexThoughts = Traverse.Create(typeof(GenderHelper)).Field("old_sex_list").GetValue<List<HediffDef>>();
+        private static readonly List<HediffDef> sexChangeThoughts = Traverse.Create(typeof(GenderHelper)).Field("SexChangeThoughts").GetValue<List<HediffDef>>();
+
+        public static void RemoveAllSexChangeThoughts(Pawn pawn)
+        {
+            // Shouldn't ever be true in the normal case, but this stops someone from calling this with an incorrect setup
+            if (pawn?.health == null)
+                return;
+
+            if(wasSexThoughts == null || sexChangeThoughts == null || !wasSexThoughts.Any() || !sexChangeThoughts.Any())
+            {
+                Log.Error($"Couldn't get values from RJW.\nold_sex_list: {wasSexThoughts.ToStringSafeEnumerable()}\nSexChangeThoughts: {sexChangeThoughts.ToStringSafeEnumerable()}");
+                return;
+            }
+
+            foreach(var def in wasSexThoughts.Concat(sexChangeThoughts))
+            {
+                var hediff = pawn.health.hediffSet.GetFirstHediffOfDef(def);
+                if (hediff != null)
+                    pawn.health.RemoveHediff(hediff);
+            }
         }
     }
 }

--- a/Source/Genes/Gender/Gene_FemaleOnly.cs
+++ b/Source/Genes/Gender/Gene_FemaleOnly.cs
@@ -24,8 +24,6 @@ namespace RJW_Genes
 
         private void AdjustPawnToFemale()
         {
-            Log.Message($"Gene_FemaleOnly AdjustPawnToFemale | {pawn} | {pawn.gender}");
-
             // Here we really use the Gender.Female and not our helper IsFemale(pawn)
             if (pawn.gender == Gender.Female)
                 return;

--- a/Source/Genes/Gender/Gene_FemaleOnly.cs
+++ b/Source/Genes/Gender/Gene_FemaleOnly.cs
@@ -4,7 +4,7 @@ using rjw;
 
 namespace RJW_Genes
 {
-    public class Gene_FemaleOnly : Gene
+    public class Gene_FemaleOnly : RJW_Gene
     {
         public override void PostMake()
         {
@@ -24,6 +24,8 @@ namespace RJW_Genes
 
         private void AdjustPawnToFemale()
         {
+            Log.Message($"Gene_FemaleOnly AdjustPawnToFemale | {pawn} | {pawn.gender}");
+
             // Here we really use the Gender.Female and not our helper IsFemale(pawn)
             if (pawn.gender == Gender.Female)
                 return;
@@ -38,5 +40,11 @@ namespace RJW_Genes
             }
         }
 
+        public override void Notify_OnPawnGeneration()
+        {
+            base.Notify_OnPawnGeneration();
+            // If this is Pawn generation, then we can assume that the pawn was never any gender other than female, so they shouldn't have sex change thoughts.
+            GenderUtility.RemoveAllSexChangeThoughts(pawn);
+        }
     }
 }

--- a/Source/Genes/Gender/Gene_MaleOnly.cs
+++ b/Source/Genes/Gender/Gene_MaleOnly.cs
@@ -4,7 +4,7 @@ using rjw;
 
 namespace RJW_Genes
 {
-    public class Gene_MaleOnly : Gene
+    public class Gene_MaleOnly : RJW_Gene
     {
         public override void PostMake()
         {
@@ -38,5 +38,11 @@ namespace RJW_Genes
             }
         }
 
+        public override void Notify_OnPawnGeneration()
+        {
+            base.Notify_OnPawnGeneration();
+            // If this is Pawn generation, then we can assume that the pawn was never any gender other than male, so they shouldn't have sex change thoughts.
+            GenderUtility.RemoveAllSexChangeThoughts(pawn);
+        }
     }
 }

--- a/Source/Genes/Patch_AddNotifyOnGeneration.cs
+++ b/Source/Genes/Patch_AddNotifyOnGeneration.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using System.Linq;
+using Verse;
+
+namespace RJW_Genes.Genes
+{
+    [HarmonyPatch]
+    public static class Patch_AddNotifyOnGeneration
+    {
+        [HarmonyPatch(typeof(PawnGenerator), "GenerateGenes")]
+        [HarmonyPostfix]
+        public static void PawnGenerator_GenerateGenes_Postfix(Pawn pawn)
+        {
+            if (pawn.genes == null) return;
+
+            foreach(var gene in pawn.genes.GenesListForReading)
+            {
+                if (gene is RJW_Gene rjwGene)
+                    rjwGene.Notify_OnPawnGeneration();
+            }
+        }
+    }
+}

--- a/Source/Genes/RJW_Gene.cs
+++ b/Source/Genes/RJW_Gene.cs
@@ -12,5 +12,13 @@ namespace RJW_Genes
             if (GenitaliaUtility.PawnStillNeedsGenitalia(pawn))
                 Sexualizer.sexualize_pawn(pawn);
         }
+
+        /// <summary>
+        /// Executed via PawnGenerator.GenerateGenes at Pawn generation
+        /// Allows for execution of code that should only happen during PawnGeneration
+        /// </summary>
+        public virtual void Notify_OnPawnGeneration()
+        {
+        }
     }
 }

--- a/Source/Rjw-Genes.csproj
+++ b/Source/Rjw-Genes.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Genes\Life_Force\ThinkNodes\ThinkNode_ConditionalCritcalLifeForce.cs" />
     <Compile Include="Genes\Life_Force\JobGivers\JobGiver_GetLifeForce.cs" />
     <Compile Include="Genes\Life_Force\ThinkNodes\ThinkNode_NewFlirtTarget.cs" />
+    <Compile Include="Genes\Patch_AddNotifyOnGeneration.cs" />
     <Compile Include="Genes\Special\Patch_AgeDrain.cs" />
     <Compile Include="Interactions\SuccubusTailjob\CompAbility_SexInteractionRequirements.cs" />
     <Compile Include="Genes\Life_Force\Abilities\CompAbilityEffect_PussyHeal.cs" />


### PR DESCRIPTION
For pawns with female-only or male-only genes, if the gene was present at Pawn Generation, remove any hediffs related to that "sex change".