### PR TITLE
Duplicate XML node name outcomeDoers - Update RJW_Used_Condoms.xml

### DIFF
--- a/Common/Patches/ThingDefs/RJW_Used_Condoms.xml
+++ b/Common/Patches/ThingDefs/RJW_Used_Condoms.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-	<!-- Add RJW Sex meditation focus icon to VanillaPsycastsExpanded -->
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>RimJobWorld</li>
-		</mods>
-		<match Class="PatchOperationAdd">
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="UsedCondom"]/ingestible/outcomeDoers</xpath>
+		<nomatch Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="UsedCondom"]/ingestible</xpath>
 			<value>
 				<outcomeDoers>
@@ -13,6 +10,14 @@
 						<FertilinPerUnit>1</FertilinPerUnit>
 					</li>
 				</outcomeDoers>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="UsedCondom"]/ingestible/outcomeDoers</xpath>
+			<value>
+				<li Class="RJW_Genes.IngestionOutcomeDoer_LifeForceOffset">
+					<FertilinPerUnit>1</FertilinPerUnit>
+				</li>
 			</value>
 		</match>
 	</Operation>


### PR DESCRIPTION
With and without Sexperience no issue with "Duplicate XML node name outcomeDoers". Instead of adding another "outcomeDoers" node when Sexperience is active, add an "li" node to the existing one.