### PR TITLE
Bugfix & error checking additions to the Animal hybrid functionality …

### DIFF
--- a/1.5/Source/Animal_Inheritance/Defs/RaceGeneDef_Helper.cs
+++ b/1.5/Source/Animal_Inheritance/Defs/RaceGeneDef_Helper.cs
@@ -1,7 +1,7 @@
-﻿using rjw;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using rjw;
 using Verse;
 
 namespace RJW_BGS
@@ -25,16 +25,16 @@ namespace RJW_BGS
 			PawnKindDef kindDef = pawn.kindDef;
 			if (kindDef == null)
 			{
-				ModLog.Warning($"Error looking up PawnKindDef for {pawn.Name} - Could not lookup Animal Inheritance Genes");
+				RJW_Genes.ModLog.Warning($"Error looking up PawnKindDef for {pawn.Name} - Could not lookup Animal Inheritance Genes");
 				return null;
 			}
 			
 			string raceName = kindDef.race.defName;
 			string pawnKindName = kindDef.defName;
 			//Wild animals have no name, so we will use pawnkindname instead
-			string pawnName = pawn.Name != null ? pawn.Name.ToStringFull : pawnKindName; 
-			PawnData pawnData = SaveStorage.DataStore.GetPawnData(pawn);
-			RaceGroupDef raceGroupDef = pawnData.RaceSupportDef;
+			string pawnName = pawn.Name != null ? pawn.Name.ToStringFull : pawnKindName;
+
+			RaceGroupDef raceGroupDef = GetRaceGroupDef(kindDef);
 
             RJW_Genes.ModLog.Debug($"Looking up Animal-Inheritable Genes for {pawnName} with KindDef {kindDef.defName},RaceName {raceName}, PawnKind {pawnKindName} and RaceGroup {raceGroupDef.defName}");
 
@@ -82,7 +82,7 @@ namespace RJW_BGS
 			}
             RJW_Genes.ModLog.Debug($"Did not find RaceGroupDefs for {pawnName}");
 
-			ModLog.Message($"Did not find any Genes inheritable for {pawnName}");
+			RJW_Genes.ModLog.Message($"Did not find any Genes inheritable for {pawnName}");
 			return new List<RaceGeneDef>();
 		}
 
@@ -94,8 +94,54 @@ namespace RJW_BGS
 				foreach (RaceGeneDef raceGeneDef in defs)
 					defString += $"({raceGeneDef.priority}:{raceGeneDef.defName} - {raceGeneDef.genes.Count} Genes)";
 				defString += "]";
-				ModLog.Message($"Found the following {header}-Genes for {identifier}: {defString}");
+				RJW_Genes.ModLog.Message($"Found the following {header}-Genes for {identifier}: {defString}");
 			}
 		}
+
+
+		/// <summary>
+		/// These two Functions are Duplicates of private functions in RJW RaceGroupDef_Helper, used to get a racegroupdef from a kindDef.
+		/// If the RaceGroupDef_Helper class is made accessable directly, these functions can be removed.
+		/// </summary>
+		/// <param name="kindDef"></param>
+		/// <returns></returns>
+        private static RaceGroupDef GetRaceGroupDef(PawnKindDef kindDef)
+        {
+            var raceName = kindDef.race.defName;
+            var pawnKindName = kindDef.defName;
+            var groups = DefDatabase<RaceGroupDef>.AllDefs;
+
+            var kindMatches = groups.Where(group => group.pawnKindNames?.Contains(pawnKindName) ?? false).ToList();
+            var raceMatches = groups.Where(group => group.raceNames?.Contains(raceName) ?? false).ToList();
+            var count = kindMatches.Count() + raceMatches.Count();
+            if (count == 0)
+            {
+                //ModLog.Message($"Pawn named '{pawn.Name}' matched no RaceGroupDef. If you want to create a matching RaceGroupDef you can use the raceName '{raceName}' or the pawnKindName '{pawnKindName}'.");
+                return null;
+            }
+            else if (count == 1)
+            {
+                // ModLog.Message($"Pawn named '{pawn.Name}' matched 1 RaceGroupDef.");
+                return kindMatches.Concat(raceMatches).Single();
+            }
+            else
+            {
+                // ModLog.Message($"Pawn named '{pawn.Name}' matched {count} RaceGroupDefs.");
+
+                // If there are multiple RaceGroupDef matches, choose one of them.
+                // First prefer defs NOT defined in rjw.
+                // Then prefer a match by kind over a match by race.
+                return kindMatches.FirstOrDefault(match => !IsThisMod(match))
+                    ?? raceMatches.FirstOrDefault(match => !IsThisMod(match))
+                    ?? kindMatches.FirstOrDefault()
+                    ?? raceMatches.FirstOrDefault();
+            }
+        }
+
+        private static bool IsThisMod(Def def)
+        {
+            var rjwContent = LoadedModManager.RunningMods.Single(pack => pack.Name == "RimJobWorld");
+            return rjwContent.AllDefs.Contains(def);
+        }
     } 
 }

--- a/1.5/Source/Animal_Inheritance/InheritanceUtility.cs
+++ b/1.5/Source/Animal_Inheritance/InheritanceUtility.cs
@@ -50,7 +50,15 @@ namespace RJW_BGS
                 {
                     if (gene.chance * RJW_BGSSettings.rjw_bgs_global_gene_chance  >= Rand.Range(0.01f,1f))
                     {
-                        genelist.Add(DefDatabase<GeneDef>.GetNamed(gene.defName));
+                        GeneDef tmpGene = DefDatabase<GeneDef>.GetNamed(gene.defName, false);
+                        if (tmpGene != null) 
+                        { 
+                            genelist.Add(tmpGene); 
+                        } 
+                        else
+                        {
+                            RJW_Genes.ModLog.Warning($"Unable to find gene {gene.defName}, skipping. May need to update {raceGeneDef.defName} definition.");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Replicating the issue Addressed.**  
- Create a Dev-start game
- Add a male cougar to the game & tame
- have a female pawn have vaginal sex with the cougar.
- Upon successful conception with the Hybrid Genes Option enabled, game will throw an error looking up raceGroupDef


**Files Altered.**

 * RaceGeneDef_Helper.cs - Replaced Depreciated Savestorage.Datastore lookup with new function copied from private method in RJW.RaceGroupDef_Helper, returns the same value, so rest of function is left unaltered.

 * InheritanceUtility.cs - Made the genelist lookup function more robust, if a gene name doesn't exist, function will now log a warning, and proceed onto the next gene in the list.